### PR TITLE
Disable input correction attributes

### DIFF
--- a/docs/sozysozbot_jvozba.html
+++ b/docs/sozysozbot_jvozba.html
@@ -31,7 +31,7 @@
 					<li>-jvo-</li>
 				</ul>
 				<form name="a" onsubmit="jvozba_gui(document.a.b.value);return false;">
-					<input type="text" name="b" id="b" value="lujvo zbasu">
+					<input type="text" name="b" id="b" value="lujvo zbasu" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false">
 					<input type="button" value="zbasu" onclick="jvozba_gui(document.a.b.value)">
 				</form>
 				<div id="res"></div>
@@ -49,7 +49,7 @@
 					<li>zgovla</li>
 				</ul>
 				<form name="c" onsubmit="jvokaha_gui(document.c.d.value);return false;">
-					<input type="text" name="d" id="d" value="jvoka'a">
+					<input type="text" name="d" id="d" value="jvoka'a" autocomplete="off" autocapitalize="off" autocorrect="off" spellcheck="false">
 					<input type="button" value="katna" onclick="jvokaha_gui(document.c.d.value)">
 				</form>
 				<div id="res2"></div>


### PR DESCRIPTION
Turn off autocomplete, autocapitalise, autocorrect, and spellcheck for the input boxes. Disabling these features makes it easier to type lojban words on mobile devices.

(I tried to make a pull request yesterday, but I'm kind of new to GitHub so I _think_ I did not. Sorry if this a duplicate somehow!)